### PR TITLE
Add display values for organization and contact point

### DIFF
--- a/registry-frontend/src/lib/data/query-dataservice-facets.rq
+++ b/registry-frontend/src/lib/data/query-dataservice-facets.rq
@@ -43,9 +43,10 @@ SELECT
             ?prop rdfs:label ?propLabelRaw .
         }
 
-        # Try to get explicit rdfs:label OR foaf:name for value if it's a resource
+        # Try to get explicit rdfs:label, foaf:name, OR vcard:fn for the value
         OPTIONAL { ?val rdfs:label ?valLabelRaw . }
         OPTIONAL { ?val foaf:name ?valNameRaw . }
+        OPTIONAL { ?val vcard:fn ?valFnRaw . }
 
         # For property: use rdfs:label if available, otherwise extract from URI
         BIND(COALESCE(?propLabelRaw, REPLACE(STR(?prop), "^.*[/#]([^/#]+)$", "$1")) AS ?propLabelRaw2)
@@ -54,8 +55,8 @@ SELECT
         BIND(REPLACE(?propLabelNoHyphens, "([a-z])([A-Z])", "$1 $2") AS ?propLabelSpaced)
         BIND(CONCAT(UCASE(SUBSTR(?propLabelSpaced, 1, 1)), SUBSTR(?propLabelSpaced, 2)) AS ?propLabel)
 
-        # For value: use foaf:name, then rdfs:label, then extract from URI, or use literal value
-        BIND(COALESCE(?valNameRaw, ?valLabelRaw,
+        # For value: use foaf:name, vcard:fn, then rdfs:label, then fallback to URI/literal
+        BIND(COALESCE(?valNameRaw, ?valFnRaw, ?valLabelRaw,
                       IF(isURI(?val), REPLACE(STR(?val), "^.*[/#]([^/#]+)$", "$1"), STR(?val)))
              AS ?valLabelRaw2)
 


### PR DESCRIPTION
## Reference

https://github.com/EOSC-EDEN/LTP-Registry/issues/4

## Description

* Previously, only generic Org_1, Org2 and Contact_1, Contact_2
* With minor modifications to the queries, we can retrieve the display values for these (Org, Contact)

## Testing

<img width="1257" height="684" alt="Screenshot from 2025-11-13 11-27-59" src="https://github.com/user-attachments/assets/dd228878-09bf-4233-9fb4-de2895b6a995" />
